### PR TITLE
Fix hint page 404 in copy-an-object-with-object.assign

### DIFF
--- a/curriculum/challenges/english/03-front-end-libraries/redux/copy-an-object-with-object.assign.english.md
+++ b/curriculum/challenges/english/03-front-end-libraries/redux/copy-an-object-with-object.assign.english.md
@@ -1,6 +1,6 @@
 ---
 id: 5a24c314108439a4d403615b
-title: Copy an Object with Object.assign
+title: Copy an Object with Object assign
 challengeType: 6
 isRequired: false
 ---


### PR DESCRIPTION
Clicking on 
`Get a hint` at https://learn.freecodecamp.org/front-end-libraries/redux/copy-an-object-with-object-assign/ 
leads to a 404 https://guide.freecodecamp.org/certifications/front-end-libraries/redux/copy-an-object-with-object-assign

The associated hint page loads at https://guide.freecodecamp.org/certifications/front-end-libraries/redux/copy-an-object-with-object.assign/ 

Changing the title would be a temporary fix for the `Get a hint` 404

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] All the files I changed are in the same world language (for example: only English changes, or only Chinese changes, etc.)
- [x] My changes do not use shortened URLs or affiliate links.

